### PR TITLE
Add home page info and publishing feature info

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-online/Invoke-SPOSiteSwap.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Invoke-SPOSiteSwap.md
@@ -44,7 +44,7 @@ If the target is the root site at <https://tenant-name.sharepoint.com,> then the
 
 1. Any Featured links defined in SharePoint Start Page at <https://tenant-name.sharepoint.com/_layouts/15/sharepoint.aspx> will not be displayed after performing the swap. If required, the Featured links should be documented so they can be manually recreated after the swap.
 2. Functionality such as external sharing and application interfaces are dependent on the policies and permissions defined at the root site. Review the source site to ensure that it has the required policies and permissions as per the existing root site. This includes external sharing settings as well as site permissions.
-3. Larger tenants that have more than ~10,000 licenses may also need to run the [Page Diagnostic Tool](https://docs.microsoft.com/office365/enterprise/page-diagnostics-for-spo) against the source site. Any analysis results that have the category Attention required (Red) or Improvement opprtunities (Orange) will need to be remediated before performing the swap.
+3. Larger tenants that have more than ~10,000 licenses may also need to run the [Page Diagnostic Tool](https://docs.microsoft.com/office365/enterprise/page-diagnostics-for-spo) against the home page of the source site (site to be swapped to the root). Any analysis results that have the category Attention required (Red) or Improvement opprtunities (Orange) will need to be remediated before performing the swap.
 
 The source and target sites can't be connected to an Office 365 group. They also can't be hub sites or associated with a hub.
 If a site is a hub site, unregister it as a hub site, swap the root site, and then register the site as a hub site. If a site is associated with a hub, disassociate the site, swap the root site, and then reassociate the site.
@@ -89,7 +89,7 @@ Archives the existing Search Center site at <https://contoso.sharepoint.com/sear
 
 URL of the source site. The site at this location must exist before performing the swap.
 
-If the target is the root site at <https://tenant-name.sharepoint.com> then the source site must be either a Modern Team Site (STS#3) or a Communication Site (SITEPAGEPUBLISHING#0).
+If the target is the root site at <https://tenant-name.sharepoint.com> then the source site must be either a Communication Site (SITEPAGEPUBLISHING#0) or a Modern Team Site (STS#3). **Please note that the publishing feature cannot be activated or have ever been activated on the source site**.
 
 If the target is the search center site at <https://tenant-name.sharepoint.com/search> then the source site must be either a Search Center Site (SRCHCEN#0) or a Basic Search Center Site (SRCHCENTERLITE#0).
 


### PR DESCRIPTION
Updated to add the detail that the Page Diag tool must be run on the home page of the source site and to explicitly call out that publishing is not supported